### PR TITLE
Convert UID2Manager To Actor

### DIFF
--- a/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootViewModel.swift
+++ b/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootViewModel.swift
@@ -23,18 +23,19 @@ class RootViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     
     init() {
-        UID2Manager.shared.$identity
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] uid2Identity in
-                self?.uid2Identity = uid2Identity
-            }).store(in: &cancellables)
-     
-        UID2Manager.shared.$identityStatus
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] identityStatus in
-                self?.identityStatus = identityStatus
-            }).store(in: &cancellables)
-
+        Task {
+            await UID2Manager.shared.$identity
+                .receive(on: DispatchQueue.main)
+                .sink(receiveValue: { [weak self] uid2Identity in
+                    self?.uid2Identity = uid2Identity
+                }).store(in: &cancellables)
+         
+            await UID2Manager.shared.$identityStatus
+                .receive(on: DispatchQueue.main)
+                .sink(receiveValue: { [weak self] identityStatus in
+                    self?.identityStatus = identityStatus
+                }).store(in: &cancellables)
+        }
     }
     
     var advertisingToken: String {
@@ -88,9 +89,11 @@ class RootViewModel: ObservableObject {
                 guard let identity = identity else {
                     return
                 }
-                UID2Manager.shared.setIdentity(identity)
-                DispatchQueue.main.async {
-                    self?.error = nil
+                Task {
+                    await UID2Manager.shared.setIdentity(identity)
+                    DispatchQueue.main.async {
+                        self?.error = nil
+                    }
                 }
             case .failure(let error):
                 DispatchQueue.main.async {
@@ -101,11 +104,15 @@ class RootViewModel: ObservableObject {
     }
  
     func handleResetButton() {
-        UID2Manager.shared.resetIdentity()
-        self.error = nil
+        Task {
+            await UID2Manager.shared.resetIdentity()
+            self.error = nil
+        }
     }
     
     func handleRefreshButton() {
-        UID2Manager.shared.refreshIdentity()
+        Task {
+            await UID2Manager.shared.refreshIdentity()
+        }
     }
 }

--- a/Sources/UID2/UID2Manager.swift
+++ b/Sources/UID2/UID2Manager.swift
@@ -135,7 +135,7 @@ public final actor UID2Manager {
             return IdentityPackage(valid: true, errorMessage: "Identity expired, refresh still valid", identity: identity, status: .expired)
         }
      
-        if self.identity == nil {
+        if self.identity == nil || self.identity?.advertisingToken == identity.advertisingToken {
             return IdentityPackage(valid: true, errorMessage: "Identity established", identity: identity, status: .established)
         }
         

--- a/Tests/UID2Tests/RefreshTokenAPITests.swift
+++ b/Tests/UID2Tests/RefreshTokenAPITests.swift
@@ -74,14 +74,10 @@ final class RefreshTokenAPITests: XCTestCase {
         // Load Local RefreshToken from JSON
         let localRefreshData = try  DataLoader.load(fileName: "refresh-token-200-optout-decrypted", fileExtension: "json")
         let localTokenResponse = try decoder.decode(RefreshTokenResponse.self, from: localRefreshData)
+        let localResponsePackage = localTokenResponse.toRefreshAPIPackage()
         
-        XCTAssertNil(refreshToken.identity?.advertisingToken)
-        XCTAssertNil(refreshToken.identity?.refreshToken)
-        XCTAssertNil(refreshToken.identity?.identityExpires)
-        XCTAssertNil(refreshToken.identity?.refreshFrom)
-        XCTAssertNil(refreshToken.identity?.refreshExpires)
-        XCTAssertNil(refreshToken.identity?.refreshResponseKey)
-        
+        XCTAssertEqual(refreshToken.status, localResponsePackage?.status)
+        XCTAssertNil(refreshToken.identity)
     }
 
     /// 🟥  `POST /v2/token/refresh` - HTTP 400 - Client Error


### PR DESCRIPTION
Refactored the original `@MainActor` class version of `UID2Manager ` to an actor object.  This will enable the identity data managed by `UID2Manager` to be accessible on different threads and queues while still safely managing shared mutable state.