### PR TITLE
SDK Properties

### DIFF
--- a/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp.xcodeproj/project.pbxproj
+++ b/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp.xcodeproj/project.pbxproj
@@ -379,7 +379,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.myopenpass.UID2SDKDevelopmentApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.uid2.UID2SDKDevelopmentApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -409,7 +409,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.myopenpass.UID2SDKDevelopmentApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.uid2.UID2SDKDevelopmentApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,10 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "UID2",
-            dependencies: []),
+            dependencies: [],
+            resources: [
+                .copy("Properties/sdk_properties.plist")
+            ]),
         .testTarget(
             name: "UID2Tests",
             dependencies: ["UID2"],

--- a/Sources/UID2/Properties/SDKProperties.swift
+++ b/Sources/UID2/Properties/SDKProperties.swift
@@ -1,0 +1,14 @@
+//
+//  SDKProperties.swift
+//  
+//
+//  Created by Brad Leege on 3/15/23.
+//
+
+import Foundation
+
+struct SDKProperties: Codable {
+    
+    let UID2Version: String
+    
+}

--- a/Sources/UID2/Properties/SDKProperties.swift
+++ b/Sources/UID2/Properties/SDKProperties.swift
@@ -9,6 +9,10 @@ import Foundation
 
 struct SDKProperties: Codable {
     
-    let UID2Version: String
+    let uid2Version: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case uid2Version = "UID2Version"
+    }
     
 }

--- a/Sources/UID2/Properties/SDKPropertyLoader.swift
+++ b/Sources/UID2/Properties/SDKPropertyLoader.swift
@@ -12,14 +12,14 @@ class SDKPropertyLoader {
     static func load() -> SDKProperties {
 
         guard let plistURL = Bundle.module.url(forResource: "sdk_properties", withExtension: "plist") else {
-            return SDKProperties(UID2Version: "")
+            return SDKProperties(uid2Version: nil)
         }
 
         let decoder = PropertyListDecoder()
 
         guard let data = try? Data.init(contentsOf: plistURL),
               let preferences = try? decoder.decode(SDKProperties.self, from: data) else {
-            return SDKProperties(UID2Version: "")
+            return SDKProperties(uid2Version: nil)
         }
 
         return preferences

--- a/Sources/UID2/Properties/SDKPropertyLoader.swift
+++ b/Sources/UID2/Properties/SDKPropertyLoader.swift
@@ -1,0 +1,29 @@
+//
+//  SDKPropertyLoader.swift
+//  
+//
+//  Created by Brad Leege on 3/15/23.
+//
+
+import Foundation
+
+class SDKPropertyLoader {
+    
+    static func load() -> SDKProperties {
+
+        guard let plistURL = Bundle.module.url(forResource: "sdk_properties", withExtension: "plist") else {
+            return SDKProperties(UID2Version: "")
+        }
+
+        let decoder = PropertyListDecoder()
+
+        guard let data = try? Data.init(contentsOf: plistURL),
+              let preferences = try? decoder.decode(SDKProperties.self, from: data) else {
+            return SDKProperties(UID2Version: "")
+        }
+
+        return preferences
+
+    }
+    
+}

--- a/Sources/UID2/Properties/sdk_properties.plist
+++ b/Sources/UID2/Properties/sdk_properties.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>UID2Version</key>
+    <string>0.1.0</string>
+</dict>
+</plist>
+

--- a/Sources/UID2/UID2Client.swift
+++ b/Sources/UID2/UID2Client.swift
@@ -14,13 +14,9 @@ internal final class UID2Client {
     private let clientVersion: String
     private let session: NetworkSession
     
-    init(uid2APIURL: String, sdkVersion: String?, _ session: NetworkSession = URLSession.shared) {
+    init(uid2APIURL: String, sdkVersion: String, _ session: NetworkSession = URLSession.shared) {
         self.uid2APIURL = uid2APIURL
-        var version = "ios"
-        if let sdkVersion = sdkVersion {
-            version += "-\(sdkVersion)"
-        }
-        self.clientVersion = version
+        self.clientVersion = "ios-\(sdkVersion)"
         self.session = session
     }
     

--- a/Sources/UID2/UID2Client.swift
+++ b/Sources/UID2/UID2Client.swift
@@ -11,10 +11,16 @@ import Foundation
 internal final class UID2Client {
     
     private let uid2APIURL: String
+    private let clientVersion: String
     private let session: NetworkSession
     
-    init(uid2APIURL: String, _ session: NetworkSession = URLSession.shared) {
+    init(uid2APIURL: String, sdkVersion: String?, _ session: NetworkSession = URLSession.shared) {
         self.uid2APIURL = uid2APIURL
+        var version = "ios"
+        if let sdkVersion = sdkVersion {
+            version += "-\(sdkVersion)"
+        }
+        self.clientVersion = version
         self.session = session
     }
     
@@ -30,7 +36,7 @@ internal final class UID2Client {
                         
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
-            request.addValue("ios-0.1", forHTTPHeaderField: "X-UID2-Client-Version")
+            request.addValue(clientVersion, forHTTPHeaderField: "X-UID2-Client-Version")
             request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
             request.httpBody = refreshToken.data(using: .utf8)
             

--- a/Sources/UID2/UID2Manager.swift
+++ b/Sources/UID2/UID2Manager.swift
@@ -50,6 +50,11 @@ public final actor UID2Manager {
     private let defaultUid2RefreshRetry: Int = 5000
             
     private init() {
+        
+        // SDK Supplied Properties
+        let properties = SDKPropertyLoader.load()
+        
+        // App Supplied Properites
         var apiUrl = defaultUid2ApiUrl
         if let apiUrlOverride = Bundle.main.object(forInfoDictionaryKey: "UID2ApiUrl") as? String, !apiUrlOverride.isEmpty {
             apiUrl = apiUrlOverride

--- a/Sources/UID2/UID2Manager.swift
+++ b/Sources/UID2/UID2Manager.swift
@@ -59,7 +59,7 @@ public final actor UID2Manager {
         if let apiUrlOverride = Bundle.main.object(forInfoDictionaryKey: "UID2ApiUrl") as? String, !apiUrlOverride.isEmpty {
             apiUrl = apiUrlOverride
         }
-        uid2Client = UID2Client(uid2APIURL: apiUrl)
+        uid2Client = UID2Client(uid2APIURL: apiUrl, sdkVersion: properties.uid2Version)
 
         var refreshTime = defaultUid2RefreshRetry
         if let refreshTimeOverride = Bundle.main.object(forInfoDictionaryKey: "UID2RefreshRetryTime") as? Int {

--- a/Sources/UID2/UID2Manager.swift
+++ b/Sources/UID2/UID2Manager.swift
@@ -35,6 +35,9 @@ public final actor UID2Manager {
     
     // MARK: - Core Components
 
+    /// UID2 SDK Version
+    public let sdkVersion: String
+    
     /// UID2Client for Network API  requests
     private let uid2Client: UID2Client
     
@@ -53,13 +56,18 @@ public final actor UID2Manager {
         
         // SDK Supplied Properties
         let properties = SDKPropertyLoader.load()
+        if let uid2Version = properties.uid2Version {
+            sdkVersion = uid2Version
+        } else {
+            sdkVersion = "unknown"
+        }
         
         // App Supplied Properites
         var apiUrl = defaultUid2ApiUrl
         if let apiUrlOverride = Bundle.main.object(forInfoDictionaryKey: "UID2ApiUrl") as? String, !apiUrlOverride.isEmpty {
             apiUrl = apiUrlOverride
         }
-        uid2Client = UID2Client(uid2APIURL: apiUrl, sdkVersion: properties.uid2Version)
+        uid2Client = UID2Client(uid2APIURL: apiUrl, sdkVersion: sdkVersion)
 
         var refreshTime = defaultUid2RefreshRetry
         if let refreshTimeOverride = Bundle.main.object(forInfoDictionaryKey: "UID2RefreshRetryTime") as? Int {

--- a/Tests/UID2Tests/RefreshTokenAPITests.swift
+++ b/Tests/UID2Tests/RefreshTokenAPITests.swift
@@ -26,7 +26,7 @@ final class RefreshTokenAPITests: XCTestCase {
         }
 
         // Load UID2Client Mocked
-        let client = UID2Client(uid2APIURL: "", MockNetworkSession("refresh-token-200-success-encrypted", "txt"))
+        let client = UID2Client(uid2APIURL: "", sdkVersion: "TEST", MockNetworkSession("refresh-token-200-success-encrypted", "txt"))
 
         // Call RefreshToken using refreshToken and refreshResponseKey from Step 1 to decrypt
         let refreshToken = try await client.refreshIdentity(refreshToken: generateToken.refreshToken,
@@ -65,7 +65,7 @@ final class RefreshTokenAPITests: XCTestCase {
         }
 
         // Load UID2Client Mocked
-        let client = UID2Client(uid2APIURL: "", MockNetworkSession("refresh-token-200-optout-encrypted", "txt"))
+        let client = UID2Client(uid2APIURL: "", sdkVersion: "TEST", MockNetworkSession("refresh-token-200-optout-encrypted", "txt"))
 
         // Call RefreshToken using refreshToken and refreshResponseKey from Step 1 to decrypt
         let refreshToken = try await client.refreshIdentity(refreshToken: generateToken.refreshToken,
@@ -85,7 +85,7 @@ final class RefreshTokenAPITests: XCTestCase {
         
         do {
             // Load UID2Client Mocked
-            let client = UID2Client(uid2APIURL: "", MockNetworkSession("refresh-token-400-client-error", "json", 400))
+            let client = UID2Client(uid2APIURL: "", sdkVersion: "TEST", MockNetworkSession("refresh-token-400-client-error", "json", 400))
             
             // Call RefreshToken using refreshToken and refreshResponseKey from Step 1 to decrypt
             let _ = try await client.refreshIdentity(refreshToken: "token", refreshResponseKey: "key")
@@ -111,7 +111,7 @@ final class RefreshTokenAPITests: XCTestCase {
         
         do {
             // Load UID2Client Mocked
-            let client = UID2Client(uid2APIURL: "", MockNetworkSession("refresh-token-400-invalid-token", "json", 400))
+            let client = UID2Client(uid2APIURL: "", sdkVersion: "TEST", MockNetworkSession("refresh-token-400-invalid-token", "json", 400))
             
             // Call RefreshToken using refreshToken and refreshResponseKey from Step 1 to decrypt
             let _ = try await client.refreshIdentity(refreshToken: "token", refreshResponseKey: "key")
@@ -137,7 +137,7 @@ final class RefreshTokenAPITests: XCTestCase {
         
         do {
             // Load UID2Client Mocked
-            let client = UID2Client(uid2APIURL: "", MockNetworkSession("refresh-token-401-unauthorized", "json", 401))
+            let client = UID2Client(uid2APIURL: "", sdkVersion: "TEST", MockNetworkSession("refresh-token-401-unauthorized", "json", 401))
             
             // Call RefreshToken using refreshToken and refreshResponseKey from Step 1 to decrypt
             let _ = try await client.refreshIdentity(refreshToken: "token", refreshResponseKey: "key")


### PR DESCRIPTION
Creates a file based system for storing and loading properties at runtime for the SDK.  Initially uses this to set the SDK Version number and make it available to `UID2Client` network calls and externally available via `UID2Manager`.
