### PR TITLE
Code Cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,18 +10,13 @@ let package = Package(
         .iOS(.v13)
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "UID2",
             targets: ["UID2"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "UID2",
             dependencies: [],

--- a/Sources/UID2/KeychainManager.swift
+++ b/Sources/UID2/KeychainManager.swift
@@ -24,7 +24,7 @@ internal final class KeychainManager {
             String(kSecAttrAccount): attrAccount,
             String(kSecAttrService): attrService,
             String(kSecReturnData): true
-        ] as CFDictionary
+        ] as [String: Any] as CFDictionary
             
         var result: AnyObject?
         SecItemCopyMatching(query, &result)
@@ -48,7 +48,7 @@ internal final class KeychainManager {
                     String(kSecClass): kSecClassGenericPassword,
                     String(kSecAttrService): attrService,
                     String(kSecAttrAccount): attrAccount
-                ] as CFDictionary
+                ] as [String: Any] as CFDictionary
                 
                 let attributesToUpdate = [String(kSecValueData): data] as CFDictionary
                 

--- a/Sources/UID2/UID2Manager.swift
+++ b/Sources/UID2/UID2Manager.swift
@@ -56,10 +56,6 @@ public final actor UID2Manager {
     /// https://github.com/IABTechLab/uid2docs/tree/main/api/v2#environments
     private let defaultUid2ApiUrl = "https://prod.uidapi.com"
     
-    /// Default Timer Refresh Period in Milliseconds
-    /// Override default by setting `UID2RefreshRetryTime` in app's Info.plist
-    private let defaultUid2RefreshRetry: Int = 5000
-            
     private init() {
         
         // SDK Supplied Properties


### PR DESCRIPTION

* Removing `defaultUid2RefreshRetry` as it has been superseded by Task based checks
* Removed default comments from Package.swift
* Fixed Lint warnings in KeychainManager.swift

