### PR TITLE
Add SDK logging

### DIFF
--- a/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootViewModel.swift
+++ b/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootViewModel.swift
@@ -23,6 +23,7 @@ class RootViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     
     init() {
+        UID2Settings.isLoggingEnabled = true
         Task {
             await UID2Manager.shared.$identity
                 .receive(on: DispatchQueue.main)

--- a/Sources/UID2/UID2Settings.swift
+++ b/Sources/UID2/UID2Settings.swift
@@ -1,0 +1,34 @@
+//
+//  UID2Settings.swift
+//
+//
+//  Created by Dave Snabel-Caunt on 23/04/2024.
+//
+
+import Foundation
+
+/// An interface for configuring `UID2Manager` behavior.
+/// These settings must be configured before calling `UID2Manager.shared` as they are read when it is initialized.
+/// Subsequent changes will be ignored.
+public final class UID2Settings: @unchecked Sendable {
+
+    // A simple synchronization queue.
+    // We do not expect settings values to be modified frequently, or after SDK initialization.
+    private static let queue = DispatchQueue(label: "UID2Settings.sync")
+
+    private static var _isLoggingEnabled = false
+
+    /// Enable OS logging. The default value is `false`.
+    public static var isLoggingEnabled: Bool {
+        get {
+            queue.sync {
+                _isLoggingEnabled
+            }
+        }
+        set {
+            queue.sync {
+                _isLoggingEnabled = newValue
+            }
+        }
+    }
+}


### PR DESCRIPTION
Where possible, logs match those use in the Android SDK.

Logging is enabled by calling the following, before accessing the `UID2Manager.shared` instance.
```
UID2Settings.isLoggingEnabled = true
```

Logs will be shown in Xcode's Console and the system Console:

<img width="683" alt="Screenshot 2024-04-24 at 17 22 06" src="https://github.com/IABTechLab/uid2-ios-sdk/assets/157314/0aa3da77-2e44-4dec-8615-c09957053539">
