### PR TITLE
Add a setting for API environment

### DIFF
--- a/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootViewModel.swift
+++ b/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootViewModel.swift
@@ -24,6 +24,7 @@ class RootViewModel: ObservableObject {
     
     init() {
         UID2Settings.shared.isLoggingEnabled = true
+        UID2Settings.shared.environment = .oregon
         Task {
             await UID2Manager.shared.$identity
                 .receive(on: DispatchQueue.main)

--- a/Sources/UID2/Environment.swift
+++ b/Sources/UID2/Environment.swift
@@ -1,0 +1,34 @@
+//
+//  Environment.swift
+//
+//
+//  Created by Dave Snabel-Caunt on 24/04/2024.
+//
+
+import Foundation
+
+/// For more information, see https://unifiedid.com/docs/getting-started/gs-environments
+public struct Environment: Hashable, Sendable {
+
+    /// API base URL
+    var endpoint: URL
+
+    /// Equivalent to `ohio`
+    public static let production = ohio
+
+    /// AWS US East (Ohio)
+    public static let ohio = Self(endpoint: URL(string: "https://prod.uidapi.com")!)
+    /// AWS US West (Oregon)
+    public static let oregon = Self(endpoint: URL(string: "https://usw.prod.uidapi.com")!)
+    /// AWS Asia Pacific (Singapore)
+    public static let singapore = Self(endpoint: URL(string: "https://sg.prod.uidapi.com")!)
+    /// AWS Asia Pacific (Sydney)
+    public static let sydney = Self(endpoint: URL(string: "https://au.prod.uidapi.com")!)
+    /// AWS Asia Pacific (Tokyo)
+    public static let tokyo = Self(endpoint: URL(string: "https://jp.prod.uidapi.com")!)
+
+    /// A custom endpoint
+    public static func custom(url: URL) -> Self {
+        Self.init(endpoint: url)
+    }
+}

--- a/Sources/UID2/UID2Client.swift
+++ b/Sources/UID2/UID2Client.swift
@@ -15,18 +15,20 @@ import Foundation
 
 internal final class UID2Client: Sendable {
     
-    private let uid2APIURL: String
+    static let defaultBaseURL = URL(string: "https://prod.uidapi.com")!
+
     private let clientVersion: String
+    private let environment: Environment
     private let session: NetworkSession
     private let log: OSLog
-
+    private var baseURL: URL { environment.endpoint }
+    
     init(
-        uid2APIURL: String,
         sdkVersion: String,
         isLoggingEnabled: Bool = false,
+        environment: Environment = .production,
         _ session: NetworkSession = URLSession.shared
     ) {
-        self.uid2APIURL = uid2APIURL
         #if os(tvOS)
         self.clientVersion = "tvos-\(sdkVersion)"
         #else
@@ -35,6 +37,7 @@ internal final class UID2Client: Sendable {
         self.log = isLoggingEnabled
             ? .init(subsystem: "com.uid2", category: "UID2Client")
             : .disabled
+        self.environment = environment
         self.session = session
     }
     
@@ -77,8 +80,7 @@ internal final class UID2Client: Sendable {
     // MARK: - Request Execution
 
     internal func urlRequest(
-        _ request: Request,
-        baseURL: URL
+        _ request: Request
     ) -> URLRequest {
         var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: true)!
         urlComponents.path = request.path
@@ -99,8 +101,7 @@ internal final class UID2Client: Sendable {
 
     private func execute(_ request: Request) async throws -> (Data, Int) {
         let urlRequest = urlRequest(
-            request,
-            baseURL: URL(string: uid2APIURL)!
+            request
         )
         return try await session.loadData(for: urlRequest)
     }

--- a/Sources/UID2/UID2Manager.swift
+++ b/Sources/UID2/UID2Manager.swift
@@ -23,7 +23,7 @@ public final actor UID2Manager {
             }
         }
     }
-    
+
     // MARK: - Publishers
             
     /// Current Identity data for the user
@@ -67,10 +67,15 @@ public final actor UID2Manager {
         self.sdkVersion = UID2SDKProperties.getUID2SDKVersion()
         
         // App Supplied Properites
-        var apiUrl = defaultUid2ApiUrl
-        if let apiUrlOverride = Bundle.main.object(forInfoDictionaryKey: "UID2ApiUrl") as? String, !apiUrlOverride.isEmpty {
-            apiUrl = apiUrlOverride
+        let environment: Environment
+        if let apiUrlOverride = Bundle.main.object(forInfoDictionaryKey: "UID2ApiUrl") as? String, 
+            !apiUrlOverride.isEmpty,
+            let apiUrl = URL(string: apiUrlOverride) {
+            environment = Environment(endpoint: apiUrl)
+        } else {
+            environment = UID2Settings.shared.environment
         }
+
         var clientVersion = "\(sdkVersion.major).\(sdkVersion.minor).\(sdkVersion.patch)"
         if self.sdkVersion == (major: 0, minor: 0, patch: 0) {
             clientVersion = "unknown"
@@ -81,9 +86,9 @@ public final actor UID2Manager {
             ? .init(subsystem: "com.uid2", category: "UID2Manager")
             : .disabled
         uid2Client = UID2Client(
-            uid2APIURL: apiUrl,
             sdkVersion: clientVersion,
-            isLoggingEnabled: isLoggingEnabled
+            isLoggingEnabled: isLoggingEnabled,
+            environment: environment
         )
 
         // Try to load from Keychain if available

--- a/Sources/UID2/UID2Settings.swift
+++ b/Sources/UID2/UID2Settings.swift
@@ -32,5 +32,21 @@ public final class UID2Settings: @unchecked Sendable {
         }
     }
 
+    private var _environment = Environment.production
+
+    /// API endpoint environment. The default value is `.production`.
+    public var environment: Environment {
+        get {
+            queue.sync {
+                _environment
+            }
+        }
+        set {
+            queue.sync {
+                _environment = newValue
+            }
+        }
+    }
+
     public static let shared = UID2Settings()
 }

--- a/Tests/UID2Tests/RefreshRequestTests.swift
+++ b/Tests/UID2Tests/RefreshRequestTests.swift
@@ -13,10 +13,9 @@ final class RefreshRequestTests: XCTestCase {
     func testRequest() async throws {
         let request = Request.refresh(token: "im-a-refresh-token")
         let client = UID2Client(
-            uid2APIURL: "https://prod.uidapi.com",
             sdkVersion: "1.2.3"
         )
-        let urlRequest = client.urlRequest(request, baseURL: URL(string: "https://prod.uidapi.com")!)
+        let urlRequest = client.urlRequest(request)
 
         var expected = URLRequest(url: URL(string: "https://prod.uidapi.com/v2/token/refresh")!)
         expected.httpMethod = "POST"

--- a/Tests/UID2Tests/RefreshTokenAPITests.swift
+++ b/Tests/UID2Tests/RefreshTokenAPITests.swift
@@ -27,7 +27,6 @@ final class RefreshTokenAPITests: XCTestCase {
 
         // Load UID2Client Mocked
         let client = UID2Client(
-            uid2APIURL: "https://prod.uidapi.com",
             sdkVersion: "TEST",
             MockNetworkSession("refresh-token-200-success-encrypted", "txt")
         )
@@ -64,7 +63,6 @@ final class RefreshTokenAPITests: XCTestCase {
 
         // Load UID2Client Mocked
         let client = UID2Client(
-            uid2APIURL: "https://prod.uidapi.com",
             sdkVersion: "TEST",
             MockNetworkSession("refresh-token-200-optout-encrypted", "txt")
         )
@@ -88,7 +86,6 @@ final class RefreshTokenAPITests: XCTestCase {
         do {
             // Load UID2Client Mocked
             let client = UID2Client(
-                uid2APIURL: "https://prod.uidapi.com",
                 sdkVersion: "TEST",
                 MockNetworkSession("refresh-token-400-client-error", "json", 400)
             )
@@ -118,7 +115,6 @@ final class RefreshTokenAPITests: XCTestCase {
         do {
             // Load UID2Client Mocked
             let client = UID2Client(
-                uid2APIURL: "https://prod.uidapi.com",
                 sdkVersion: "TEST",
                 MockNetworkSession("refresh-token-400-invalid-token", "json", 400)
             )
@@ -148,7 +144,6 @@ final class RefreshTokenAPITests: XCTestCase {
         do {
             // Load UID2Client Mocked
             let client = UID2Client(
-                uid2APIURL: "https://prod.uidapi.com",
                 sdkVersion: "TEST",
                 MockNetworkSession("refresh-token-401-unauthorized", "json", 401)
             )

--- a/Tests/UID2Tests/UID2ClientTests.swift
+++ b/Tests/UID2Tests/UID2ClientTests.swift
@@ -1,0 +1,47 @@
+//
+//  UID2ClientTests.swift
+//
+//
+//  Created by Dave Snabel-Caunt on 25/04/2024.
+//
+
+@testable import UID2
+import XCTest
+
+final class UID2ClientTests: XCTestCase {
+
+    func testDefaultEnvironment() async throws {
+        let client = UID2Client(
+            sdkVersion: "1.0"
+        )
+        let urlRequest = client.urlRequest(.init(path: "/path"))
+        XCTAssertEqual(
+            urlRequest.url,
+            URL(string: "https://prod.uidapi.com/path")!
+        )
+    }
+
+    func testOverridenEnvironment() async throws {
+        let client = UID2Client(
+            sdkVersion: "1.0",
+            environment: .singapore
+        )
+        let urlRequest = client.urlRequest(.init(path: "/path"))
+        XCTAssertEqual(
+            urlRequest.url,
+            URL(string: "https://sg.prod.uidapi.com/path")!
+        )
+    }
+
+    func testCustomEnvironment() async throws {
+        let client = UID2Client(
+            sdkVersion: "1.0",
+            environment: .custom(url: URL(string: "http://localhost:8080/")!)
+        )
+        let urlRequest = client.urlRequest(.init(path: "/path"))
+        XCTAssertEqual(
+            urlRequest.url,
+            URL(string: "http://localhost:8080/path")!
+        )
+    }
+}


### PR DESCRIPTION
To set a custom environment, either use the existing Info.plist method:

```
plutil -replace UID2ApiUrl -string "http://localhost:8080" Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/Info.plist
```

alternatively in code call the following before accessing `UID2Manager.shared`:

```
UID2Settings.shared.environment = .sydney
```

Regarding `UID2Settings`, I explored alternatives, but `UID2Manager` performs a refresh in its `init` method, so this is the only way I can see to avoid race conditions with the current singleton structure.