### PR TITLE
Improve CSTG error reporting

### DIFF
--- a/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootView.swift
+++ b/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootView.swift
@@ -71,3 +71,26 @@ struct RootView: View {
         .padding()
     }
 }
+
+extension TokenGenerationError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .requestFailure(statusCode, message):
+            let formattedMessage: String?
+            if let message,
+                let jsonObject = try? JSONSerialization.jsonObject(with: Data(message.utf8)),
+               let jsonString = try? JSONSerialization.data(withJSONObject: jsonObject, options: .prettyPrinted) {
+                formattedMessage = String(data: jsonString, encoding: .utf8)
+            } else {
+                formattedMessage = message
+            }
+            return "Request failure (\(statusCode)):\n\(formattedMessage ?? "")"
+        case .decryptionFailure:
+            return "Response decryption failed"
+        case .configuration(let message):
+            return "Invalid configuration: \(message ?? "<none>")"
+        case .invalidResponse:
+            return "Invalid response"
+        }
+    }
+}

--- a/Sources/UID2/CryptoUtil.swift
+++ b/Sources/UID2/CryptoUtil.swift
@@ -38,7 +38,7 @@ extension CryptoUtil {
         // Server public key is provided with a 9 byte prefix. The remainder is base64 encoded.
         let encodedKey = Data(string.utf8.dropFirst(serverPublicKeyPrefixLength))
         guard let decodedSPKI = Data(base64Encoded: encodedKey) else {
-            throw UID2Error.configuration(message: "Invalid server key as base64")
+            throw TokenGenerationError.configuration(message: "Invalid server key as base64")
         }
 
         let result = try DER.parse(Array(decodedSPKI))
@@ -48,7 +48,7 @@ extension CryptoUtil {
         do {
             return try P256.KeyAgreement.PublicKey(x963Representation: privateKeyData)
         } catch {
-            throw UID2Error.configuration(message: "Invalid server key representation")
+            throw TokenGenerationError.configuration(message: "Invalid server key representation")
         }
     }
 

--- a/Sources/UID2/UID2Error.swift
+++ b/Sources/UID2/UID2Error.swift
@@ -22,7 +22,19 @@ enum UID2Error: Error {
     
     /// Unable to convert RefreshTokenResponse to RefreshAPIPackage
     case refreshResponseToRefreshAPIPackage
-       
+}
+
+public enum TokenGenerationError: Error {
+
+    /// The API request failed
+    case requestFailure(httpStatusCode: Int, response: String?)
+
+    /// Unable to decrypt response data
+    case decryptionFailure
+
     /// Invalid configuration
     case configuration(message: String?)
+
+    /// The request succeeded, but the response is missing required fields or has an invalid status
+    case invalidResponse
 }

--- a/Sources/UID2/UID2Manager.swift
+++ b/Sources/UID2/UID2Manager.swift
@@ -167,7 +167,7 @@ public final actor UID2Manager {
     ) async throws {
         assert((appName ?? Bundle.main.bundleIdentifier) != nil, "An appName must be provided or a main bundleIdentifier set")
         guard let appName = appName ?? Bundle.main.bundleIdentifier else {
-            throw UID2Error.configuration(message: "An appName must be provided or a main bundleIdentifier set")
+            throw TokenGenerationError.configuration(message: "An appName must be provided or a main bundleIdentifier set")
         }
         let apiResponse = try await uid2Client.generateIdentity(
             identity,

--- a/Tests/UID2Tests/UID2ClientTests.swift
+++ b/Tests/UID2Tests/UID2ClientTests.swift
@@ -87,7 +87,7 @@ final class UID2ClientTests: XCTestCase {
                 appName: "com.example.app"
             )
         ) { error in
-            guard let error = error as? UID2Error,
+            guard let error = error as? TokenGenerationError,
             case let .configuration(message: message) = error else {
                 XCTFail("Expected UID2Error.configuration, got \(error)")
                 return
@@ -115,9 +115,9 @@ final class UID2ClientTests: XCTestCase {
                 appName: "com.example.app"
             )
         ) { error in
-            guard let error = error as? UID2Error,
-            case .decryptPayloadData = error else {
-                XCTFail("Expected UID2Error.decryptPayloadData, got \(error)")
+            guard let error = error as? TokenGenerationError,
+            case .decryptionFailure = error else {
+                XCTFail("Expected TokenGenerationError.decryptionFailure, got \(error)")
                 return
             }
         }
@@ -142,9 +142,9 @@ final class UID2ClientTests: XCTestCase {
                 appName: "com.example.app"
             )
         ) { error in
-            guard let error = error as? UID2Error,
-            case .decryptPayloadData = error else {
-                XCTFail("Expected UID2Error.decryptPayloadData, got \(error)")
+            guard let error = error as? TokenGenerationError,
+            case .decryptionFailure = error else {
+                XCTFail("Expected TokenGenerationError.decryptionFailure, got \(error)")
                 return
             }
         }
@@ -171,9 +171,9 @@ final class UID2ClientTests: XCTestCase {
                 appName: "com.example.app"
             )
         ) { error in
-            guard let error = error as? UID2Error,
-            case .refreshTokenServerDecoding = error else {
-                XCTFail("Expected UID2Error.refreshTokenServerDecoding, got \(error)")
+            guard let error = error as? TokenGenerationError,
+            case .requestFailure = error else {
+                XCTFail("Expected TokenGenerationError.requestFailure, got \(error)")
                 return
             }
         }


### PR DESCRIPTION
Makes response data available as part of the error:

<img width="448" alt="Screenshot 2024-05-07 at 12 00 20" src="https://github.com/IABTechLab/uid2-ios-sdk/assets/157314/c331cb26-d8ae-4f20-86e5-76332469927a">

Also improves the dev app display of errors:

<img src="https://github.com/IABTechLab/uid2-ios-sdk/assets/157314/ef660583-b84b-463f-a1b5-dee42deb3440" width="400" />