### PR TITLE
Improve error reporting for public key parsing

### DIFF
--- a/Sources/UID2/CryptoUtil.swift
+++ b/Sources/UID2/CryptoUtil.swift
@@ -38,17 +38,16 @@ extension CryptoUtil {
         // Server public key is provided with a 9 byte prefix. The remainder is base64 encoded.
         let encodedKey = Data(string.utf8.dropFirst(serverPublicKeyPrefixLength))
         guard let decodedSPKI = Data(base64Encoded: encodedKey) else {
-            throw TokenGenerationError.configuration(message: "Invalid server key as base64")
+            throw TokenGenerationError.configuration(message: "Invalid server public key as base64")
         }
 
-        let result = try DER.parse(Array(decodedSPKI))
-        let publicKey = try Certificate.PublicKey(derEncoded: result)
-
-        let privateKeyData = publicKey.subjectPublicKeyInfoBytes
         do {
+            let result = try DER.parse(Array(decodedSPKI))
+            let publicKey = try Certificate.PublicKey(derEncoded: result)
+            let privateKeyData = publicKey.subjectPublicKeyInfoBytes
             return try P256.KeyAgreement.PublicKey(x963Representation: privateKeyData)
         } catch {
-            throw TokenGenerationError.configuration(message: "Invalid server key representation")
+            throw TokenGenerationError.configuration(message: "Invalid server public key representation")
         }
     }
 

--- a/Tests/UID2Tests/UID2ClientTests.swift
+++ b/Tests/UID2Tests/UID2ClientTests.swift
@@ -92,7 +92,7 @@ final class UID2ClientTests: XCTestCase {
                 XCTFail("Expected UID2Error.configuration, got \(error)")
                 return
             }
-            XCTAssertEqual(message, "Invalid server key as base64")
+            XCTAssertEqual(message, "Invalid server public key as base64")
         }
     }
 


### PR DESCRIPTION
Throw a `TokenGenerationError` for malformed server public key rather then exposing the underlying ASN1 or certificate parsing error.