### PR TITLE
Only use integration env for dev app bundle identifier

### DIFF
--- a/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/Info.plist
+++ b/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/Info.plist
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>UID2ApiUrl</key>
-	<string>https://operator-integ.uidapi.com</string>
-</dict>
+<dict/>
 </plist>

--- a/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootViewModel.swift
+++ b/Development/UID2SDKDevelopmentApp/UID2SDKDevelopmentApp/RootViewModel.swift
@@ -27,7 +27,13 @@ class RootViewModel: ObservableObject {
     
     init() {
         UID2Settings.shared.isLoggingEnabled = true
-        
+        // Only the development app should use the integration environment.
+        // If you have copied the dev app for testing, you probably want to use the default
+        // environment, which is production.
+        if Bundle.main.bundleIdentifier == "com.uid2.UID2SDKDevelopmentApp" {
+            UID2Settings.shared.environment = .custom(url: URL(string: "https://operator-integ.uidapi.com")!)
+        }
+
         Task {
             await UID2Manager.shared.$identity
                 .receive(on: DispatchQueue.main)

--- a/Sources/UID2/UID2Client.swift
+++ b/Sources/UID2/UID2Client.swift
@@ -15,9 +15,6 @@ import Foundation
 @preconcurrency import OSLog
 
 internal final class UID2Client: Sendable {
-    
-    static let defaultBaseURL = URL(string: "https://prod.uidapi.com")!
-
     private let clientVersion: String
     private let environment: Environment
     private let session: NetworkSession
@@ -125,6 +122,9 @@ internal final class UID2Client: Sendable {
             let statusCode = response.statusCode
             let responseText = String(data: data, encoding: .utf8) ?? "<none>"
             os_log("Request failure (%d) %@", log: log, type: .error, statusCode, responseText)
+            if environment != .production {
+                os_log("Failed request is using non-production API endpoint %@, is this intentional?", log: log, type: .error, baseURL.description)
+            }
             throw TokenGenerationError.requestFailure(
                 httpStatusCode: statusCode,
                 response: responseText


### PR DESCRIPTION
While the Development App is not a sample, a number of publishers have used it to quickly validate their integration. As the Development app is configured for integration testing, using the integration API endpoint, this causes confusion as it doesn't work with publisher parameters.

This change only uses the integration environment when the app's bundle identifier matches that of the Development app, reducing the chance of this occurring, and adds additional logging when client requests fail in non-production environments.