### PR TITLE
Fix manager state observation and associated tests

### DIFF
--- a/Sources/UID2/UID2Manager.swift
+++ b/Sources/UID2/UID2Manager.swift
@@ -60,8 +60,9 @@ public final actor UID2Manager {
                 identityStatus = .noIdentity
             }
 
-            queue.enqueue {
-                await self.broadcaster.send(self.state)
+            // Capture the current value in the queue operation
+            queue.enqueue { [state] in
+                await self.broadcaster.send(state)
             }
         }
     }


### PR DESCRIPTION
After fixing the flaky test, it was clear that there was also a bug in the state observation stream. By capturing `self.state`, it was not evaluated until the enqueued operation actually executed, but we need to capture the value of `state` at the time of enqueuing.

Test failure rate was previously somewhere between 10% and 25% of runs. I've left the tests running on a loop and I'm confident they are no longer flaky.