### PR TITLE
Add platform availability to EUIDManager

### DIFF
--- a/Sources/UID2/EUIDManager.swift
+++ b/Sources/UID2/EUIDManager.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@available(iOS 13, tvOS 13, *)
 public final class EUIDManager {
 
     /// Singleton access point for EUID Manager


### PR DESCRIPTION
Add an `@availability` annotation to the new `EUIDManager` so that we can release iOS 12 support.