### PR TITLE
Only include swift in podspec source_files

### DIFF
--- a/UID2.podspec.json
+++ b/UID2.podspec.json
@@ -26,7 +26,7 @@
     ]
   },
   "source_files": [
-    "Sources/UID2/**/*"
+    "Sources/UID2/**/*.swift"
   ],
   "dependencies": {
     "SwiftASN1": [

--- a/UID2Prebid.podspec.json
+++ b/UID2Prebid.podspec.json
@@ -25,7 +25,7 @@
     ]
   },
   "source_files": [
-    "UID2Prebid/UID2Prebid/**/*"
+    "UID2Prebid/UID2Prebid/**/*.swift"
   ],
   "dependencies": {
     "UID2": [


### PR DESCRIPTION
Xcode warns there is no rule to process the `PrivacyInfo.xcprivacy` file. Remove it from sources, as it is a resource.