### PR TITLE
UID2-6799 Use 'ci-auto-merge' environment

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -16,4 +16,5 @@ jobs:
       uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-to-ios-version.yaml@v3
       with:
         release_type: ${{ inputs.release_type }}
+        merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
       secrets: inherit


### PR DESCRIPTION
## Summary
Pass `merge_environment: 'ci-auto-merge'` on protected branches so the release workflow uses the UID2SourceAdmin PAT to bypass the PR review ruleset when auto-merging the version bump PR.