### PR TITLE
UID2-7042: Bump SPM minimum platform to iOS 13 / tvOS 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,11 +6,9 @@ import PackageDescription
 let package = Package(
     name: "UID2",
     defaultLocalization: "en",
-    // NB: The UID2 framework code only runs on iOS 13 & tvOS 13, however this allows
-    // integration in apps supporting iOS 12.
     platforms: [
-        .iOS(.v12),
-        .tvOS(.v12)
+        .iOS(.v13),
+        .tvOS(.v13)
     ],
     products: [
         .library(


### PR DESCRIPTION
## Summary

- Bumps the `Package.swift` minimum platforms from `.iOS(.v12)` / `.tvOS(.v12)` to `.iOS(.v13)` / `.tvOS(.v13)`.
- Removes the now-stale comment that justified the iOS 12 floor.

## Why

`PrebidMobile` 3.3.1 (added to the dependency graph in #80 via `.upToNextMajor(from: "3.1.0")`) requires `.iOS(.v13)`. Swift Package Manager enforces that all products in the graph satisfy the package's declared minimum, so any consumer adding the `UID2Prebid` product on an iOS 12 target hits:

> The package product 'PrebidMobile' requires minimum platform version 13.0 for the iOS platform, but this target supports 12.0

Per the existing comment in `Package.swift`, the UID2 framework code itself already only runs on iOS 13 / tvOS 13, so the v12 declaration was only a convenience for downstream apps. With `UID2Prebid` now in the package, that convenience can no longer hold.

Fixes [#87](https://github.com/IABTechLab/uid2-ios-sdk/issues/87). Tracked internally as [UID2-7042](https://thetradedesk.atlassian.net/browse/UID2-7042).

## Test plan

- [ ] CI green
- [ ] `swift package resolve` succeeds with PrebidMobile 3.3.1
- [ ] Consumer Xcode project with iOS 13+ target can add `UID2Prebid` via SPM and build