### PR TITLE
chore: upgrade GitHub Actions from Node 20 to Node 24

### DIFF
--- a/.github/workflows/lint-prebid-podspec.yml
+++ b/.github/workflows/lint-prebid-podspec.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Select Xcode 16.4
         run: sudo xcode-select -s /Applications/Xcode_16.4.app


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners. Starting **June 16, 2026**, runners will use Node 24 by default.

This PR upgrades outdated action references in this repo to the latest released version that ships Node 24 support, pinned to its commit SHA. Each action's node version is determined by reading its `action.yml` at the pinned ref.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
