### PR TITLE
UID2-7011: add zizmor workflow-security scan (report-only)

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,16 @@
+name: Zizmor Scan
+
+on:
+  pull_request:
+    # Must cover everywhere scannable files live; the scan covers the whole repo.
+    paths:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    # Bare call: severity floors come from the shared workflow's defaults.
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-zizmor-scan.yaml@v3


### PR DESCRIPTION
Adds the zizmor GitHub Actions security scan (UID2-7011) as a **report-only** check: it blocks nothing and shows findings (High severity and above) in the job summary when workflow files change.

The caller is deliberately **bare** — severity floors inherit the shared workflow's central defaults, so org-wide retunes are a single change in uid2-shared-actions rather than per-repo PRs. See the [zizmor section of the uid2-shared-actions README](https://github.com/IABTechLab/uid2-shared-actions#zizmor-workflow-security-scanning).

Part of the org-wide rollout tracked in UID2-7011; gating comes later, after existing High findings are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)